### PR TITLE
📖 DOC: Add alias block to .gitconfig instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ funcsave gtst
 If you prefer, you can paste these aliases directly in your `~/.gitconfig` file:
 
 ```sh
-[alias]
+# Make sure you're adding under the [alias] block.
+[alias] 
   # Git Commit, Add all and Push — in one step.
   cap = "!f() { git add .; git commit -m \"$@\"; git push; }; f"
 

--- a/README.md
+++ b/README.md
@@ -139,21 +139,22 @@ funcsave gtst
 If you prefer, you can paste these aliases directly in your `~/.gitconfig` file:
 
 ```sh
-# Git Commit, Add all and Push — in one step.
-cap = "!f() { git add .; git commit -m \"$@\"; git push; }; f"
+[alias]
+  # Git Commit, Add all and Push — in one step.
+  cap = "!f() { git add .; git commit -m \"$@\"; git push; }; f"
 
-# NEW.
-new = "!f() { git cap \"📦 NEW: $@\"; }; f"
-# IMPROVE.
-imp = "!f() { git cap \"👌 IMPROVE: $@\"; }; f"
-# FIX.
-fix = "!f() { git cap \"🐛 FIX: $@\"; }; f"
-# RELEASE.
-rlz = "!f() { git cap \"🚀 RELEASE: $@\"; }; f"
-# DOC.
-doc = "!f() { git cap \"📖 DOC: $@\"; }; f"
-# TEST.
-tst = "!f() { git cap \"✅ TEST: $@\"; }; f"
+  # NEW.
+  new = "!f() { git cap \"📦 NEW: $@\"; }; f"
+  # IMPROVE.
+  imp = "!f() { git cap \"👌 IMPROVE: $@\"; }; f"
+  # FIX.
+  fix = "!f() { git cap \"🐛 FIX: $@\"; }; f"
+  # RELEASE.
+  rlz = "!f() { git cap \"🚀 RELEASE: $@\"; }; f"
+  # DOC.
+  doc = "!f() { git cap \"📖 DOC: $@\"; }; f"
+  # TEST.
+  tst = "!f() { git cap \"✅ TEST: $@\"; }; f"
 ```
 
 <br>


### PR DESCRIPTION
When adding commands to a ~/.gitconfig file they need to be nested in an `[alias]` block.