### PR TITLE
🐛 FIX: git alias for BREAKING

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -176,7 +176,7 @@ If you prefer, you can paste these aliases directly in your `~/.gitconfig` file:
   # TEST.
   tst = "!f() { git cap \"🤖 TEST: $@\"; }; f"
   # BREAKING CHANGE.
-  tst = "!f() { git cap \"‼️ BREAKING: $@\"; }; f"
+  brk = "!f() { git cap \"‼️ BREAKING: $@\"; }; f"
 ```
 
 <br>


### PR DESCRIPTION
Currently the alias `tst` is documented for test AND breaking change - latter should be `brk`.