### PR TITLE
README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ I like emoji. I like ’em a lot. Programming, code, geeks/nerds, open-source, a
 1. **RULES** ↓
     - A small number of categories — easy to memorize.
     - Nothing more nothing less.
-    - E.g. `📦 NEW`, `👌 IMPROVE`, `🐛 FIX`, `📖 DOC`, `🚀 RELEASE`, `🤖 TEST`, and `‼️ BREAKING`
+    - E.g. `📦 NEW`, `👌 IMPROVE`, `🐛 FIX`, `📖 DOC`, `🚀 RELEASE`, `🤖 TEST`, and `❗️ BREAKING`
 1. **ACTIONS** ↓
     - Make git commits based on the actions you take.
     - Use a good editor like [VSCode](https://code.visualstudio.com/) to commit the right files with commit messages.
@@ -64,9 +64,9 @@ Only use the following Git Commit Messages. A simple and small footprint is crit
     > E.g. `🤖 TEST: Mock User Login/Logout`
 
 
-1. `‼️ BREAKING: IMPERATIVE_MESSAGE_GOES_HERE`
+1. `❗️ BREAKING: IMPERATIVE_MESSAGE_GOES_HERE`
     > Use when releasing a change that breaks previous versions.
-    > E.g. `‼️ BREAKING: Change authentication protocol`
+    > E.g. `❗️ BREAKING: Change authentication protocol`
 
 _— That's it for now. Nothing more nothing less._
 
@@ -84,7 +84,7 @@ I'd like to share what each of these emojis mean.
 - `📖 DOCS:` Emoji meaning: A "book emoji" — which means documentation or notes just like in a book.
 - `🚀 RELEASE:` Emoji meaning: A "rocket emoji" — which is meant to show a new release/launch.
 - `🤖 TEST:` Emoji meaning: A "robot emoji" — which says some test were run successfully.
-- `‼️ BREAKING:` Emoji meaning: A "bangbang emoji" — which attracts attention to a breaking change.
+- `❗️ BREAKING:` Emoji meaning: A "bangbang emoji" — which attracts attention to a breaking change.
 
 ##### VSCode Extension
 
@@ -104,12 +104,12 @@ function gcap() {
 }
 
 # NEW.
-function gnew() {
+gnew() {
     gcap "📦 NEW: $@"
 }
 
 # IMPROVE.
-function gimp() {
+gimp() {
     gcap "👌 IMPROVE: $@"
 }
 
@@ -119,7 +119,7 @@ function gfix() {
 }
 
 # RELEASE.
-function grlz() {
+grlz() {
     gcap "🚀 RELEASE: $@"
 }
 
@@ -129,13 +129,25 @@ function gdoc() {
 }
 
 # TEST.
-function gtst() {
+gtst() {
     gcap "🤖 TEST: $@"
 }
 
 # BREAKING CHANGE.
-function gbrk() {
-    gcap "‼️ BREAKING: $@"
+gbrk() {
+    gcap "❗️ BREAKING: $@"
+}
+# List all of the types of log messages in an aesthetic way
+NORMAL='\033[0;39m'
+GREEN='\033[0;32m'
+gtype() {
+    echo "$GREEN gnew$NORMAL -- 📦 NEW
+$GREEN gimp$NORMAL -- 👌 IMPROVE
+$GREEN gfix$NORMAL -- 🐛 FIX
+$GREEN grlz$NORMAL -- 🚀 RELEASE
+$GREEN gdoc$NORMAL -- 📖 DOC
+$GREEN gtst$NORMAL -- 🧪️ TEST
+$GREEN gbrk$NORMAL -- ❗️ BREAKING"
 }
 ```
 
@@ -151,7 +163,7 @@ function gfix; gcap "🐛 FIX: $argv"; end;
 function grlz; gcap "🚀 RELEASE: $argv"; end;
 function gdoc; gcap "📖 DOC: $argv"; end;
 function gtst; gcap "🤖 TEST: $argv"; end;
-function gbrk; gcap "‼️ BREAKING: $argv"; end;
+function gbrk; gcap "❗️ BREAKING: $argv"; end;
 funcsave gcap
 funcsave gnew
 funcsave gimp
@@ -185,7 +197,7 @@ If you prefer, you can paste these aliases directly in your `~/.gitconfig` file:
   # TEST.
   tst = "!f() { git cap \"🤖 TEST: $@\"; }; f"
   # BREAKING CHANGE.
-  brk = "!f() { git cap \"‼️ BREAKING: $@\"; }; f"
+  brk = "!f() { git cap \"❗️ BREAKING: $@\"; }; f"
 ```
 
 <br>
@@ -219,15 +231,15 @@ To setup:
 
 This will give the following text expander keywords for the Emoji-Log:
 
-| Keyword |   Snippet    |
-| ------- | ------------ |
+| Keyword |    Snippet     |
+| -------- | ------------- |
 | `;gnew` | 📦 NEW:      |
 | `;gimp` | 👌 IMPROVE:  |
 | `;gfix` | 🐛 FIX:      |
 | `;grlz` | 🚀 RELEASE:  |
 | `;gdoc` | 📖 DOC:      |
 | `;gtst` | 🤖 TEST:     |
-| `;gbrk` | ‼️ BREAKING:  |
+| `;gbrk` | ❗️ BREAKING: |
 
 To edit the `;` prefix to your preferred expansion flag, double click right click the Emoji-Log Collection in _Alfred Settings » Features » Snippets_.
 


### PR DESCRIPTION
- readme.md --> README.md
- change breaking to an emoji thats supported in windows AND *nix ‼️ --> ❗️
- bash `function` keyword breaks in some versions of bash, safer to remove it
- Bash helper function to list out the items in an aesthetic way so you don't need to memorize all of them:

```bash
NORMAL='\033[0;39m'
GREEN='\033[0;32m'
gtype() {
    echo "$GREEN gnew$NORMAL -- 📦 NEW
$GREEN gimp$NORMAL -- 👌 IMPROVE
$GREEN gfix$NORMAL -- 🐛 FIX
$GREEN grlz$NORMAL -- 🚀 RELEASE
$GREEN gdoc$NORMAL -- 📖 DOC
$GREEN gtst$NORMAL -- 🧪️ TEST
$GREEN gbrk$NORMAL -- ❗️ BREAKING"
}
```